### PR TITLE
'Local' seems to be forgetten to translate, fix it

### DIFF
--- a/target/zh-CN/vscode-editor/vs_platform.xlf
+++ b/target/zh-CN/vscode-editor/vs_platform.xlf
@@ -1472,7 +1472,7 @@
     <body>
       <trans-unit id="local">
         <source xml:lang="en">Local</source>
-        <target state="translated">ju</target>
+        <target state="translated">本地</target>
       </trans-unit>
       <trans-unit id="issueReporterWriteToClipboard">
         <source xml:lang="en">There is too much data to send to GitHub directly. The data will be copied to the clipboard, please paste it into the GitHub issue page that is opened.</source>


### PR DESCRIPTION
As I mentioned in [pull-request of vscode-loc](https://github.com/microsoft/vscode-loc/pull/185), the word 'Local' seems to be translated to 'JU' incorrectly. 'JU' is not even a legal chinese word or character. The word 'local' can be translated to 2 words in chinese: '本地' and '局部'. The previous one should be used in circumstances like 'Local Environment' while the latter one used like 'Local Variable'. 